### PR TITLE
[fix] Claude .mcp.json toolbox entry missing "type" — agents ran with zero tools

### DIFF
--- a/docs/architecture/containers.md
+++ b/docs/architecture/containers.md
@@ -54,6 +54,6 @@ Four containers on the `agento-net` bridge network.
 
 All containers communicate on `agento-net` (bridge). DNS names match service names: `toolbox`, `mysql`.
 
-Agent connects to Toolbox via MCP. Claude uses SSE at `http://toolbox:3001/sse` (written to `.mcp.json`); Codex uses streamable HTTP at `http://toolbox:3001/mcp` (written to `.codex/config.toml`). Each agent's `ConfigWriter` constructs the URL from the shared `core/toolbox/url` base value.
+Agent connects to Toolbox via MCP. Both agents use streamable HTTP at `http://toolbox:3001/mcp` — Claude via `.mcp.json` (`{"type": "http", "url": …}`; the `type` discriminator is mandatory, a typeless entry is dropped at validation), Codex via `.codex/config.toml`. Each agent's `ConfigWriter` constructs the URL from the shared `core/toolbox/url` base value. The deprecated SSE transport at `/sse` is still served for operator-pinned `type: sse` entries.
 
 Source: [docker/docker-compose.yml](../../docker/docker-compose.yml)

--- a/docs/architecture/data-flow.html
+++ b/docs/architecture/data-flow.html
@@ -326,7 +326,7 @@
         <div class="card-body">
           Per-provider <code>ConfigWriter</code> writes credentials
           (<code>~/.claude/.credentials.json</code> / <code>~/.codex/config.toml</code>) and injects the toolbox MCP server entry:
-          <code>{ "toolbox": { "url": "http://toolbox:3001/sse" } }</code>.
+          <code>{ "toolbox": { "type": "http", "url": "http://toolbox:3001/mcp" } }</code>.
         </div>
       </div>
 

--- a/docs/architecture/zero-trust.md
+++ b/docs/architecture/zero-trust.md
@@ -26,7 +26,7 @@ Toolbox is the **only** container with access to secrets. The AI agent has no cr
 │  database passwords, API tokens    │
 │  (except its own OAuth)            │
 └───────────┬────────────────────────┘
-            │ MCP over SSE (Claude) or streamable HTTP (Codex) — no credentials in request
+            │ MCP over streamable HTTP (Claude + Codex) — no credentials in request
             ▼
 ┌────────────────────────────────────┐
 │  Toolbox                           │

--- a/docs/config/core-config-data.md
+++ b/docs/config/core-config-data.md
@@ -96,7 +96,7 @@ The `core` module provides these framework-level config paths:
 | `core/server_concurrency_budget` | integer | `10` | Process-wide maximum active SQL operations per adapter/host/port; default scope only |
 | `core/email_whitelist` | string | — | Allowed email recipients (comma-separated) |
 | `core/allowed_domains` | string | — | Allowed browser domains (comma-separated) |
-| `core/toolbox/url` | string | `"http://toolbox:3001"` | Toolbox base URL. Agent `ConfigWriter` implementations append their transport path (`/mcp` for Codex, `/sse` for Claude). Jira also reads this for REST calls. |
+| `core/toolbox/url` | string | `"http://toolbox:3001"` | Toolbox base URL. Agent `ConfigWriter` implementations append their transport path (`/mcp` for both Claude and Codex). Jira also reads this for REST calls. |
 
 All DB timestamps are stored in UTC. The `core/timezone` setting is for code that needs to reason in local time (e.g., idempotency key bucketing, future display). ENV override: `CONFIG__CORE__TIMEZONE`.
 

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -1,12 +1,12 @@
 # MCP Tools
 
-Tools are exposed to the AI agent via MCP (Model Context Protocol). The Toolbox serves two transports: SSE at `/sse` (used by Claude) and streamable HTTP at `/mcp` (used by Codex). The Toolbox discovers and registers tools from modules at startup.
+Tools are exposed to the AI agent via MCP (Model Context Protocol). The Toolbox serves two transports: streamable HTTP at `/mcp` (used by both Claude and Codex) and SSE at `/sse` (deprecated, still served for compatibility and operator-pinned `type: sse` entries). The Toolbox discovers and registers tools from modules at startup.
 
 ## Architecture
 
 ```
 Agent (cron/sandbox)                    Toolbox
-┌─────────────┐    MCP/SSE    ┌─────────────────────────┐
+┌─────────────┐    MCP/HTTP   ┌─────────────────────────┐
 │ Claude CLI   │◄────────────►│ MCP Server (:3001)      │
 │ reads .mcp.json             │                         │
 │                             │ ┌─────────────────────┐ │

--- a/src/agento/modules/claude/src/config.py
+++ b/src/agento/modules/claude/src/config.py
@@ -6,6 +6,7 @@ import logging
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit
 
 from agento.framework.agent_manager.token_store import update_refreshed_credentials
 
@@ -30,6 +31,31 @@ _AUTH_IDENTITY_KEYS = frozenset({
     "firstStartTime",
     "hasCompletedOnboarding",
 })
+
+
+def _derive_mcp_type(name: str, server_cfg: dict) -> str | None:
+    """Infer the ``.mcp.json`` type discriminator for an entry that omits it.
+
+    Claude Code validates each entry on ``type``; a typeless URL entry defaults
+    to ``stdio``, then fails for lacking ``command``, and the server is dropped.
+    Warnings identify the entry by name only — operator URLs may carry
+    credentials (userinfo or a query token).
+    """
+    if "command" in server_cfg:
+        return "stdio"
+    url = server_cfg.get("url")
+    if not isinstance(url, str) or not url:
+        return None
+    try:
+        path = urlsplit(url).path.rstrip("/")
+    except ValueError:
+        path = ""
+    if path.endswith("/sse"):
+        return "sse"
+    if path.endswith("/mcp"):
+        return "http"
+    logger.warning("MCP server %r: cannot derive type from URL, defaulting to http", name)
+    return "http"
 
 
 def _load_json(path: Path) -> dict[str, Any]:
@@ -244,8 +270,10 @@ class ClaudeConfigWriter:
             return
         servers = data.get("mcpServers", {})
         for server_cfg in servers.values():
-            url = server_cfg.get("url", "")
-            if "/sse" in url or "/mcp" in url:
+            if not isinstance(server_cfg, dict):
+                continue
+            url = server_cfg.get("url")
+            if isinstance(url, str) and ("/sse" in url or "/mcp" in url):
                 sep = "&" if "?" in url else "?"
                 server_cfg["url"] = f"{url}{sep}job_id={job_id}"
         mcp_path.write_text(json.dumps(data, indent=2))
@@ -374,21 +402,36 @@ class ClaudeConfigWriter:
         # Auto-inject the toolbox MCP entry; operators can add more (or shadow
         # "toolbox") via agent_view/mcp/servers.
         servers: dict[str, dict] = {
-            "toolbox": {"url": f"{toolbox_url.rstrip('/')}/sse"},
+            "toolbox": {"type": "http", "url": f"{toolbox_url.rstrip('/')}/mcp"},
         }
         extra_raw = agent_config.get("mcp/servers")
         if extra_raw:
+            extra: Any = {}
             try:
                 extra = json.loads(extra_raw)
-                if isinstance(extra, dict):
-                    servers.update(extra)
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Invalid JSON in agent_view/mcp/servers, ignoring extras")
+            if isinstance(extra, dict):
+                for name, server_cfg in extra.items():
+                    if not isinstance(server_cfg, dict):
+                        logger.warning("MCP server %r is not an object, ignoring", name)
+                        continue
+                    server_cfg = dict(server_cfg)
+                    if "type" not in server_cfg:
+                        derived = _derive_mcp_type(name, server_cfg)
+                        if derived is None:
+                            logger.warning(
+                                "MCP server %r has no type and none can be derived, ignoring",
+                                name,
+                            )
+                            continue
+                        server_cfg["type"] = derived
+                    servers[name] = server_cfg
 
         if agent_view_id is not None:
             for server_cfg in servers.values():
-                url = server_cfg.get("url", "")
-                if "/sse" in url or "/mcp" in url:
+                url = server_cfg.get("url")
+                if isinstance(url, str) and ("/sse" in url or "/mcp" in url):
                     sep = "&" if "?" in url else "?"
                     server_cfg["url"] = f"{url}{sep}agent_view_id={agent_view_id}"
 

--- a/tests/unit/modules/claude/test_config.py
+++ b/tests/unit/modules/claude/test_config.py
@@ -97,7 +97,102 @@ class TestPrepareWorkspace:
         assert not (work_dir / ".claude.json").exists()
         assert not (work_dir / ".claude" / "settings.json").exists()
         data = json.loads((work_dir / ".mcp.json").read_text())
-        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/sse"
+        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/mcp"
+
+    def test_toolbox_entry_has_explicit_type(self, writer, work_dir):
+        writer.prepare_workspace(work_dir, {}, toolbox_url=self.TOOLBOX)
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["toolbox"] == {
+            "type": "http",
+            "url": "http://toolbox:3001/mcp",
+        }
+
+    def test_every_generated_server_entry_has_a_type(self, writer, work_dir):
+        servers = '{"other": {"url": "http://other:4000/sse"}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]
+        for name, cfg in data["mcpServers"].items():
+            assert "type" in cfg, f"{name} has no type"
+
+    def test_derives_sse_for_sse_extra(self, writer, work_dir):
+        servers = '{"other": {"url": "http://other:4000/sse"}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["other"]["type"] == "sse"
+
+    def test_derives_stdio_for_command_extra(self, writer, work_dir):
+        servers = '{"local": {"command": "npx", "args": ["-y", "server"]}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["local"]["type"] == "stdio"
+        assert "url" not in data["mcpServers"]["local"]
+
+    def test_defaults_to_http_for_ambiguous_url(self, writer, work_dir):
+        servers = '{"other": {"url": "https://example.com/api"}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["other"]["type"] == "http"
+
+    def test_malformed_url_falls_back_to_http(self, writer, work_dir):
+        servers = '{"other": {"url": "http://[::1"}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["other"]["type"] == "http"
+
+    def test_does_not_log_mcp_url_secrets(self, writer, work_dir, caplog):
+        servers = '{"other": {"url": "https://user:sup3rsecret@example.com/api?key=t0ken"}}'
+        with caplog.at_level("WARNING"):
+            writer.prepare_workspace(
+                work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+            )
+        assert "sup3rsecret" not in caplog.text
+        assert "t0ken" not in caplog.text
+        assert "example.com" not in caplog.text
+        assert "other" in caplog.text
+
+    def test_explicit_operator_type_is_preserved(self, writer, work_dir):
+        servers = '{"toolbox": {"type": "sse", "url": "http://toolbox:3001/sse"}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["toolbox"] == {
+            "type": "sse",
+            "url": "http://toolbox:3001/sse",
+        }
+
+    def test_drops_untypeable_extra(self, writer, work_dir):
+        servers = '{"weird": {"foo": 1}}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers}, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert list(data["mcpServers"].keys()) == ["toolbox"]
+
+    def test_non_dict_extra_is_dropped_and_toolbox_survives(self, writer, work_dir):
+        servers = '{"toolbox": "nope", "weird": 1}'
+        writer.prepare_workspace(
+            work_dir, {"mcp/servers": servers},
+            agent_view_id=3, toolbox_url=self.TOOLBOX,
+        )
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"] == {
+            "toolbox": {
+                "type": "http",
+                "url": "http://toolbox:3001/mcp?agent_view_id=3",
+            },
+        }
 
     def test_extras_merge_with_toolbox_mcp(self, writer, work_dir):
         extras = '{"other": {"command": "npx", "args": ["-y", "server"]}}'
@@ -110,7 +205,7 @@ class TestPrepareWorkspace:
     def test_always_writes_toolbox_when_no_extras(self, writer, work_dir):
         writer.prepare_workspace(work_dir, {"model": "opus"}, toolbox_url=self.TOOLBOX)
         data = json.loads((work_dir / ".mcp.json").read_text())
-        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/sse"
+        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/mcp"
 
     def test_ignores_invalid_extras_json(self, writer, work_dir):
         writer.prepare_workspace(
@@ -119,17 +214,17 @@ class TestPrepareWorkspace:
         data = json.loads((work_dir / ".mcp.json").read_text())
         assert list(data["mcpServers"].keys()) == ["toolbox"]
 
-    def test_appends_agent_view_id_to_toolbox_sse_url(self, writer, work_dir):
+    def test_appends_agent_view_id_to_toolbox_url(self, writer, work_dir):
         writer.prepare_workspace(
             work_dir, {}, agent_view_id=2, toolbox_url=self.TOOLBOX,
         )
         data = json.loads((work_dir / ".mcp.json").read_text())
-        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/sse?agent_view_id=2"
+        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/mcp?agent_view_id=2"
 
     def test_no_agent_view_id_leaves_url_unchanged(self, writer, work_dir):
         writer.prepare_workspace(work_dir, {}, toolbox_url=self.TOOLBOX)
         data = json.loads((work_dir / ".mcp.json").read_text())
-        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/sse"
+        assert data["mcpServers"]["toolbox"]["url"] == "http://toolbox:3001/mcp"
 
     def test_does_not_modify_non_mcp_urls(self, writer, work_dir):
         servers = '{"other": {"type": "stdio", "command": "node"}}'
@@ -174,6 +269,40 @@ class TestInjectRuntimeParams:
 
         data = json.loads((work_dir / ".mcp.json").read_text())
         assert "job_id=5" in data["mcpServers"]["toolbox"]["url"]
+
+    def test_preserves_type(self, writer, work_dir):
+        mcp = {
+            "mcpServers": {
+                "toolbox": {
+                    "type": "http",
+                    "url": "http://toolbox:3001/mcp?agent_view_id=1",
+                },
+            },
+        }
+        (work_dir / ".mcp.json").write_text(json.dumps(mcp))
+
+        writer.inject_runtime_params(work_dir, job_id=7)
+
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["toolbox"]["type"] == "http"
+        assert "job_id=7" in data["mcpServers"]["toolbox"]["url"]
+
+    def test_tolerates_malformed_entries(self, writer, work_dir):
+        mcp = {
+            "mcpServers": {
+                "broken": "nope",
+                "numeric": {"type": "http", "url": 123},
+                "toolbox": {"type": "http", "url": "http://toolbox:3001/mcp"},
+            },
+        }
+        (work_dir / ".mcp.json").write_text(json.dumps(mcp))
+
+        writer.inject_runtime_params(work_dir, job_id=8)
+
+        data = json.loads((work_dir / ".mcp.json").read_text())
+        assert data["mcpServers"]["broken"] == "nope"
+        assert data["mcpServers"]["numeric"]["url"] == 123
+        assert "job_id=8" in data["mcpServers"]["toolbox"]["url"]
 
 
 class TestWriteCredentials:


### PR DESCRIPTION
## Problem

`ClaudeConfigWriter._write_mcp_json` wrote the toolbox MCP entry as `{"url": "<toolbox>/sse"}` with **no `type`**.

Claude Code ≥2.x validates each `.mcp.json` server on the `type` discriminator (`sse` | `http` | `stdio`). A typeless *URL* entry defaults to `stdio`, then fails validation for lacking `command`, so the entry is dropped. The sandbox runs the CLI with `--strict-mcp-config`, so there is no fallback to user/project config.

Result: **every Claude agent_view ran with an empty tool supply** — `mcp_servers: []` in session init, `toolbox_mcp_connected=0`, `toolbox_mcp_calls=0` — while the job still reported SUCCESS. Most visible on Outlook mail tasks, where the prompt tells the agent to call `outlook_get_message` / `outlook_reply`: those tools did not exist, so no reply was ever sent and the user saw "no response" despite SUCCESS. Reconfirmed on job 74213 (2026-07-26).

Operator extras (`agent_view/mcp/servers`) were merged verbatim via `servers.update(extra)`, so a typeless operator entry was dropped the same way.

`CodexConfigWriter` already emitted `type`, which is why Codex views were unaffected.

## Fix

`src/agento/modules/claude/src/config.py`

- **Toolbox default is now `{"type": "http", "url": "<toolbox>/mcp"}`** — streamable HTTP, matching Codex and the toolbox's stateful `/mcp` endpoint (`toolbox/server.js:118`), which Codex already drives in production. `/sse` stays served for operator-pinned `type: sse` entries. Deliberately **not** `"streamable_http"` — that is Codex's TOML spelling and is invalid in `.mcp.json`.
- **New `_derive_mcp_type(name, server_cfg)`** fills in the discriminator for operator extras that omit it: `command` → `stdio`; URL **path** (via `urlsplit`, not a substring of the whole string) ending `/sse` → `sse`, `/mcp` → `http`; ambiguous → `http` with a warning; untypeable → entry dropped. `urlsplit`'s `ValueError` on malformed input (e.g. `http://[::1`) is caught.
- **No log statement emits a URL value** — warnings identify the entry by server name only, because operator MCP URLs routinely carry credentials (userinfo, or a `?key=` token) and consumer logs are structured and retained.
- **Operator extras are validated per entry before merging**, so a malformed entry can no longer crash the `agent_view_id` loop (previously `AttributeError: 'str' object has no attribute 'get'` — reproduced in the new tests) and a garbage entry named `toolbox` can no longer displace the working default.
- An **explicit operator-supplied `type` is always preserved**, so the documented `config:set` workaround keeps working.
- `inject_runtime_params` hardened against non-dict values / non-string urls in an on-disk `.mcp.json` (it round-trips the file, which may be stale or hand-edited). `type` survives the round-trip.

The invariant is scoped to what `_write_mcp_json()` emits from the current resolved config — `migrate_legacy_workspace_config()` merges a legacy `.mcp.json` and `inject_runtime_params()` preserves hand edits; both are crash-hardened here but not retyped, which would be a broader behaviour change.

## Tests

`tests/unit/modules/claude/test_config.py` — **64 passed**. Added: explicit-type regression on the toolbox entry, the "every generated entry has a type" invariant, `sse`/`stdio`/ambiguous/malformed-URL derivation, explicit-type preservation, untypeable + non-dict extras dropped (exercised **with a non-null `agent_view_id`**, which is what reproduced the pre-fix crash), no-URL-secrets-in-logs via `caplog`, and `inject_runtime_params` type preservation + malformed tolerance.

Full `bin/test` green: **62 passed, 0 failed** (2236 Python unit, 416 JS, e2e 2 passed / 6 skipped).

## Docs

Corrected the "Claude uses SSE" claims and the typeless example: `docs/tools/README.md` (prose + ASCII diagram label), `docs/config/core-config-data.md`, `docs/architecture/containers.md`, `docs/architecture/data-flow.html` (showed the exact typeless shape that caused this bug), `docs/architecture/zero-trust.md`.

## Follow-ups (not in this PR)

- `CodexConfigWriter._derive_mcp_type` (`src/agento/modules/codex/src/config.py:29`) logs the raw MCP URL — the same credential-leak shape fixed here on the Claude side.
- No assertion exists that an agent actually sees ≥1 tool. That silence is what let this ship: a job can succeed with zero tools. `toolbox_mcp_connected` / `toolbox_mcp_calls` already exist to detect it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
