### PR TITLE
[fix] Classify revoked/stale-token 401s as transient auth: throttle + fail over instead of dead-lettering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (direct mode). If you previously hand-created inert `outlook_sender` ingress bindings, re-create
   them as regexes (`ingress:list` shows existing rows) — this is a note, not a migration.
 
+### Fixed
+- **Jobs no longer dead-letter on `401 OAuth access token has been revoked` while healthy tokens sit
+  unused in the pool.** The message previously matched no known phrase, degraded to a generic
+  `RuntimeError`, and so never poisoned or throttled the token nor set `retry_with_other_token` —
+  leaving the deterministic `ORDER BY priority ASC` token selection to hand back the *same* broken
+  credential on every retry (observed in production on two separate jobs: 3 identical attempts →
+  `DEAD`). Revoked/stale-token rejections are now classified as a new **transient auth** category:
+  the token gets a 15-minute `throttled_until` cooldown (**not** `status='error'` — it is usually
+  still serving other jobs) and the job fails over to the next healthy token, dead-lettering only
+  once the pool is genuinely exhausted. Both the Claude and Codex providers classify revoked/stale-token
+  wording; Claude additionally classifies **unrecognised** `401` credential-rejection wording as
+  transient, so a future change to the CLI's error text fails over instead of silently retrying the
+  same credential.
+- New `token_auth_throttled_after` event (`TokenAuthThrottledEvent`) — dispatched when a transient
+  auth failure throttles a token rather than poisoning it.
+
+### Known issues
+- The underlying credential-refresh race at `AGENTO_CONSUMER_MAX_WORKERS > 1` (a concurrent job
+  rotates a token while another attempt is holding an older copy) is unchanged. The transient-auth
+  category makes it survivable rather than fatal; closing the race itself is tracked separately.
+
 ## [0.1.0] - 2024-01-01
 
 ### Added

--- a/docs/architecture/data-flow.html
+++ b/docs/architecture/data-flow.html
@@ -341,11 +341,13 @@
           <span class="evt before"><a href="../../src/agento/framework/consumer.py#L436">agent_view_run_start_before</a></span>
           <span class="evt after"><a href="../../src/agento/framework/consumer.py#L523">agent_view_run_finish_after</a></span>
           <span class="evt after"><a href="../../src/agento/framework/consumer.py#L555">token_auth_failed_after</a></span>
+          <span class="evt after"><a href="../../src/agento/framework/consumer.py#L555">token_auth_throttled_after</a></span>
         </div>
       </div>
 
       <div class="card callout">
-        <code>token_auth_failed_after</code> only fires on runtime auth failure — flips the row in <code>oauth_token</code> to <code>status='error'</code> so the LRU pool skips it.
+        <code>token_auth_failed_after</code> fires only on a <strong>permanent</strong> runtime auth failure — flips the row in <code>oauth_token</code> to <code>status='error'</code> so the LRU pool skips it until an operator clears it.
+        A <strong>transient</strong> credential rejection (revoked/stale access token, or unrecognised <code>401</code> wording) instead fires <code>token_auth_throttled_after</code> and sets a 15-minute <code>throttled_until</code> cooldown — <code>status</code> stays <code>'ok'</code> and the token self-recovers, because the same credential is usually still serving other jobs.
       </div>
     </div>
 

--- a/docs/architecture/events.md
+++ b/docs/architecture/events.md
@@ -179,8 +179,11 @@ Examples: `job_claim_after`, `module_register_before`, `workspace_build_complete
 |-------|-----------|--------|------|
 | `token_auth_failed_after` | `TokenAuthFailedEvent` | `agent_type, token_id, error_msg, job_id` | A runtime auth failure flips a token to `status='error'` (permanent poison) |
 | `token_usage_limited_after` | `TokenUsageLimitedEvent` | `agent_type, token_id, error_msg, reset_at, job_id` | A session/usage/rate limit throttles a token via `throttled_until` (temporary cooldown; `status` stays `'ok'`) |
+| `token_auth_throttled_after` | `TokenAuthThrottledEvent` | `agent_type, token_id, error_msg, throttled_until, job_id` | A **transient** auth failure (revoked/stale access token) throttles a token via `throttled_until` (`status` stays `'ok'`; no poison) |
 
 `token_usage_limited_after` is distinct from `token_auth_failed_after`: a usage limit is **temporary**, so the consumer sets `oauth_token.throttled_until = reset_at` (a cooldown the pool skips until it passes — the token auto-recovers) and the job fails over to another healthy token, whereas an auth failure **poisons** the token (`status='error'`) until an operator or credential-refresh clears it. Both are internal events (defined in `framework/events.py`, not re-exported from `framework/contracts/`).
+
+`token_auth_throttled_after` is the third member of this family: unlike `token_auth_failed_after` it does **not** poison the token (the credential is usually still live — a revoked/stale *access token* typically means this run got an out-of-date copy), and unlike `token_usage_limited_after` the cause is a credential rejection rather than a quota. It is deliberately left unbound — in particular it must NOT trigger `workspace_build`'s `ReplaceErroredTokenCredentialsObserver`, which exists to evict a *poisoned* token's dead credentials.
 
 ### Config & Setup Lifecycle
 

--- a/docs/cli/tokens.md
+++ b/docs/cli/tokens.md
@@ -32,7 +32,7 @@ Health state lives on each row:
 | `used_at`    | Last time a worker claimed the row — drives LRU ordering within a priority tier. |
 | `priority`   | Pool selection weight. Lower value wins; 0 = default.                   |
 
-**Three ways a token leaves the pool (in increasing permanence):**
+**Four ways a token leaves the pool (in increasing permanence):**
 - **Throttled** (`throttled_until` in the future, `status='ok'`): hit a session/usage/rate limit. Temporary — the token auto-recovers at the reset time and the job **fails over** to another healthy token meanwhile. No operator action needed.
 - **Transient-auth throttled** (`throttled_until` in the future, `status='ok'`): the CLI rejected the stored credential with a revoked/stale-token 401. Temporary — the same token label is often still serving other jobs, so it is **not** poisoned; the job fails over to another healthy token and this one returns to the pool after 15 minutes. No operator action needed.
 - **Expired** (`expires_at` in the past): credential lapsed. Cleared by `token:refresh`.
@@ -52,7 +52,9 @@ Health state lives on each row:
 ## Token Lifecycle
 
 ```
-register → [use via LRU+priority] → (auto-flagged error on 401) → refresh | reset → deregister
+register → [use via LRU+priority] → (transient 401 → 15-min throttle, self-recovers)
+                                  → (permanent auth failure → auto-flagged status='error')
+                                  → refresh | reset → deregister
 ```
 
 ## Register a Token

--- a/docs/cli/tokens.md
+++ b/docs/cli/tokens.md
@@ -25,15 +25,16 @@ Health state lives on each row:
 
 | Column       | Meaning                                                                 |
 |--------------|-------------------------------------------------------------------------|
-| `status`     | `ok` or `error`. Flipped to `error` when the runner classifies an authentication failure (e.g. invalid credentials or expired OAuth) — not every transient `401`. |
+| `status`     | `ok` or `error`. Flipped to `error` only on a **known-permanent** auth failure (invalid credentials, expired OAuth, not logged in). A revoked/stale access token — or any further wording the **provider module** classifies as a transient credential rejection — is treated as **transient** instead: a short `throttled_until` cooldown, `status` stays `ok`. (Claude additionally classifies unrecognised `401` credential-rejection wording this way; Codex covers revoked/stale-token wording only.) |
 | `error_msg`  | Operator-visible reason for the latest failure.                         |
 | `expires_at` | Credential expiry (from the stored payload). A row is skipped once `expires_at` is in the **past** (a *future* value means still-valid). **Claude OAuth leaves this NULL on purpose** — see the note below. |
-| `throttled_until` | Temporary usage/session-limit **cooldown**. Set to the limit's reset time when the provider account is rate/usage-limited. The pool skips the token while `throttled_until` is in the **future** and auto-includes it once it passes. Distinct from `expires_at` (credential expiry) and from `status='error'` (poison): `status` stays `'ok'` and the token self-recovers. |
+| `throttled_until` | Temporary **cooldown**. Set either to a usage/session limit's reset time (default 1h when unparseable), or to `now + 15 min` on a **transient auth failure** (revoked/stale access token — usually a concurrent-refresh race, not a dead credential). The pool skips the token while `throttled_until` is in the **future** and auto-includes it once it passes. Distinct from `expires_at` (credential expiry) and from `status='error'` (poison): `status` stays `'ok'` and the token self-recovers. |
 | `used_at`    | Last time a worker claimed the row — drives LRU ordering within a priority tier. |
 | `priority`   | Pool selection weight. Lower value wins; 0 = default.                   |
 
 **Three ways a token leaves the pool (in increasing permanence):**
 - **Throttled** (`throttled_until` in the future, `status='ok'`): hit a session/usage/rate limit. Temporary — the token auto-recovers at the reset time and the job **fails over** to another healthy token meanwhile. No operator action needed.
+- **Transient-auth throttled** (`throttled_until` in the future, `status='ok'`): the CLI rejected the stored credential with a revoked/stale-token 401. Temporary — the same token label is often still serving other jobs, so it is **not** poisoned; the job fails over to another healthy token and this one returns to the pool after 15 minutes. No operator action needed.
 - **Expired** (`expires_at` in the past): credential lapsed. Cleared by `token:refresh`.
 - **Errored** (`status='error'`): auth failure poisoned it. Cleared by `token:reset` or `token:refresh`.
 

--- a/src/agento/framework/agent_manager/errors.py
+++ b/src/agento/framework/agent_manager/errors.py
@@ -50,3 +50,25 @@ class UsageLimitError(RuntimeError):
         # healthy alternative remains in the pool, so the job retries onto it.
         # ``retry_policy.evaluate`` reads this flag (mirrors AuthenticationError).
         self.retry_with_other_token = False
+
+
+class TransientAuthError(RuntimeError):
+    """Raised when an agent CLI rejects a stored credential in a way that does NOT
+    prove the credential is dead — e.g. ``401 OAuth access token has been revoked``,
+    usually a stale access-token copy from a concurrent refresh rather than a revoked
+    account (the same token label keeps serving other jobs).
+
+    Handled like ``UsageLimitError``, not ``AuthenticationError``: the consumer
+    THROTTLES the token briefly (``oauth_token.throttled_until``; ``status`` stays
+    ``'ok'``) so the pool skips it, the job fails over, and the token auto-recovers
+    with no operator action. ``retry_with_other_token`` is set by the consumer when a
+    healthy alternative remains; ``retry_policy.evaluate`` reads it.
+
+    Deliberately NOT a subclass of ``AuthenticationError``, whose ``except`` clause
+    would otherwise poison it.
+    """
+
+    def __init__(self, message: str, *, token_id: int | None = None) -> None:
+        super().__init__(message)
+        self.token_id = token_id
+        self.retry_with_other_token = False

--- a/src/agento/framework/consumer.py
+++ b/src/agento/framework/consumer.py
@@ -9,7 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 
-from .agent_manager.errors import AuthenticationError, UsageLimitError
+from .agent_manager.errors import AuthenticationError, TransientAuthError, UsageLimitError
 from .agent_manager.models import AgentProvider
 from .agent_manager.token_resolver import TokenResolver
 from .agent_manager.token_store import (
@@ -38,6 +38,7 @@ from .events import (
     JobSucceededEvent,
     JobVerificationFailed,
     TokenAuthFailedEvent,
+    TokenAuthThrottledEvent,
     TokenUsageLimitedEvent,
     WorkerStartedEvent,
     WorkerStoppedEvent,
@@ -55,6 +56,12 @@ from .workflows.base import JobContext
 # boundary; 1h keeps the token out of the pool long enough to fail over while still
 # recovering on its own.
 _DEFAULT_LIMIT_THROTTLE = timedelta(hours=1)
+
+# Transient auth failures (revoked/stale access token) get a SHORT cooldown, not the
+# 1h usage-limit window: the credential itself is usually fine and heals on the next
+# refresh capture. 15 min outlasts the 60s/300s retry backoffs, so attempts 2 and 3
+# are guaranteed to land on a different token, while still auto-recovering fast.
+_DEFAULT_TRANSIENT_AUTH_THROTTLE = timedelta(minutes=15)
 
 
 @dataclass
@@ -565,6 +572,10 @@ class Consumer:
                 else f"subtype={result.subtype or '?'} {result.stats_line}"
             )
             return _JobResult.from_run_result(result, summary)
+        except TransientAuthError as exc:
+            success = False
+            self._handle_transient_auth(job, token, agent_type, exc)
+            raise
         except UsageLimitError as exc:
             success = False
             self._handle_usage_limit(job, token, agent_type, exc)
@@ -903,3 +914,48 @@ class Consumer:
                 conn.close()
                 if finalize_after_pending:
                     em.dispatch("job_finalize_after", finalize_event)
+
+    def _handle_transient_auth(
+        self,
+        job: Job,
+        token,
+        agent_type: AgentProvider,
+        exc: TransientAuthError,
+    ) -> None:
+        """Throttle a token whose credential was rejected in a way that does NOT prove
+        it is dead (revoked/stale access token) — a short cooldown via
+        ``throttled_until``, NOT ``status='error'``: poisoning would take a token that
+        is still serving other jobs out of rotation. Best-effort — DB issues here must
+        not mask the original failure about to be re-raised."""
+        token_id = exc.token_id if exc.token_id is not None else token.id
+        until = datetime.now(UTC).replace(tzinfo=None) + _DEFAULT_TRANSIENT_AUTH_THROTTLE
+        try:
+            conn = get_connection(self._db_config)
+            try:
+                throttle_token(conn, token_id, until, str(exc), logger=self.logger)
+                conn.commit()
+                _total, healthy = count_tokens_for_provider(conn, agent_type)
+                exc.retry_with_other_token = healthy > 0
+            finally:
+                conn.close()
+        except Exception:
+            self.logger.exception(
+                "Failed to throttle token after transient auth failure",
+                extra={"job_id": job.id, "token_id": token_id},
+            )
+        try:
+            get_event_manager().dispatch(
+                "token_auth_throttled_after",
+                TokenAuthThrottledEvent(
+                    agent_type=agent_type.value,
+                    token_id=token_id,
+                    error_msg=str(exc),
+                    throttled_until=until,
+                    job_id=job.id,
+                ),
+            )
+        except Exception:
+            self.logger.exception(
+                "token_auth_throttled_after observer failed",
+                extra={"job_id": job.id, "token_id": token_id},
+            )

--- a/src/agento/framework/events.py
+++ b/src/agento/framework/events.py
@@ -489,3 +489,18 @@ class TokenUsageLimitedEvent:
     error_msg: str
     reset_at: datetime | None = None
     job_id: int | None = None
+
+
+@dataclass
+class TokenAuthThrottledEvent:
+    """Dispatched when a TRANSIENT auth failure (e.g. a revoked/stale access token)
+    throttles a token instead of poisoning it — ``throttled_until`` is set, ``status``
+    stays ``'ok'``, and the token auto-recovers. Distinct from
+    ``TokenAuthFailedEvent`` (permanent poison) and from ``TokenUsageLimitedEvent``
+    (a quota limit, not a credential problem). ``throttled_until`` is naive UTC."""
+
+    agent_type: str
+    token_id: int
+    error_msg: str
+    throttled_until: datetime | None = None
+    job_id: int | None = None

--- a/src/agento/framework/retry_policy.py
+++ b/src/agento/framework/retry_policy.py
@@ -13,6 +13,7 @@ NON_RETRYABLE_ERRORS = frozenset({
     "KeyError",
     "AuthenticationError",  # token expired — retrying won't help
     "UsageLimitError",  # session/usage limit — terminal unless a healthy token remains
+    "TransientAuthError",  # stale/revoked credential — terminal unless a healthy token remains
 })
 
 
@@ -68,9 +69,11 @@ def evaluate(
     # healthy alternatives. The consumer sets ``retry_with_other_token`` on the
     # exception when another healthy token exists, so the job retries onto the next
     # token instead of dead-lettering on the first bad/limited credential.
-    if error_class in ("AuthenticationError", "UsageLimitError") and getattr(
-        error_obj, "retry_with_other_token", False
-    ):
+    if error_class in (
+        "AuthenticationError",
+        "UsageLimitError",
+        "TransientAuthError",
+    ) and getattr(error_obj, "retry_with_other_token", False):
         if attempt >= max_attempts:
             return RetryDecision(
                 should_retry=False,

--- a/src/agento/modules/claude/src/output_parser.py
+++ b/src/agento/modules/claude/src/output_parser.py
@@ -6,7 +6,11 @@ import re
 from datetime import UTC, datetime, timedelta
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
-from agento.framework.agent_manager.errors import AuthenticationError, UsageLimitError
+from agento.framework.agent_manager.errors import (
+    AuthenticationError,
+    TransientAuthError,
+    UsageLimitError,
+)
 from agento.framework.runner import McpInitReport, McpServerStatus, RunResult
 
 AUTH_ERROR_PHRASES = (
@@ -25,6 +29,27 @@ LIMIT_ERROR_PHRASES = (
     "rate_limit_error",
 )
 
+# A transient credential rejection needs BOTH a credential-context word AND a rejection
+# signal. Either signal alone is too weak to act on:
+#   * credential word alone  -> "the access token could not be read from disk" (a local
+#                               file problem; throttling the pool token fixes nothing)
+#   * rejection signal alone -> "workspace access has been revoked" / "permission has
+#                               been revoked" (an authorization failure inside the run,
+#                               not a bad pool credential), or "401234 tokens".
+# Both regexes scan the WHOLE message, so the rule is order-independent: the observed
+# wording puts the auth verb BEFORE the code ("Failed to authenticate. API Error:
+# 401 ..."), future wording may not.
+# \b401\b, not "401" as a substring — a substring test matches "401234 tokens".
+# Bare "token" is deliberately absent from the credential words — Claude says "tokens"
+# about usage accounting constantly ("max tokens", "input tokens").
+_CREDENTIAL_WORD_RE = re.compile(
+    r"authenticat|unauthorized|oauth|access token|credential|bearer|api key|"
+    r"sign in|signed in|log in|logged in",
+    re.IGNORECASE,
+)
+_401_CODE_RE = re.compile(r"\b401\b")
+_REVOKED_RE = re.compile(r"revok", re.IGNORECASE)  # revoked / revoke / revocation
+
 # "resets 1pm (Europe/Warsaw)" / "resets 1:30am (America/New_York)" — capture clock + tz.
 _RESET_RE = re.compile(
     r"resets?\s+(\d{1,2})(?::(\d{2}))?\s*([ap]m)?\s*\(([^)]+)\)",
@@ -40,6 +65,7 @@ __all__ = [
     "LIMIT_ERROR_PHRASES",
     "AuthenticationError",
     "ClaudeResult",
+    "TransientAuthError",
     "UsageLimitError",
     "parse_claude_output",
 ]
@@ -79,14 +105,32 @@ def _parse_reset_at(msg: str, now: datetime | None = None) -> datetime | None:
     return candidate.astimezone(UTC).replace(tzinfo=None)
 
 
+def _is_transient_credential_rejection(msg: str) -> bool:
+    if not _CREDENTIAL_WORD_RE.search(msg):
+        return False
+    return bool(_401_CODE_RE.search(msg) or _REVOKED_RE.search(msg))
+
+
 def _classify_error(msg: str):
     """Return the exception to raise for a Claude ``is_error`` result message.
-    Auth phrases (permanent) win over limit phrases (temporary)."""
+
+    Order matters:
+    1. Known-permanent auth phrases -> AuthenticationError (poison the token).
+    2. Limit phrases -> UsageLimitError (throttle to reset_at + fail over); checked
+       before the transient rule so a limit message carrying a 401 keeps its parsed
+       ``reset_at``.
+    3. Credential word + (401 | revoked) -> TransientAuthError (short throttle + fail
+       over, no poison). Covers the reported revoked-token message AND future 401
+       wording.
+    4. Anything else -> RuntimeError (generic retry).
+    """
     if any(p in msg for p in AUTH_ERROR_PHRASES):
         return AuthenticationError(f"Claude CLI error: {msg}")
     low = msg.lower()
     if any(p in low for p in LIMIT_ERROR_PHRASES):
         return UsageLimitError(f"Claude CLI error: {msg}", reset_at=_parse_reset_at(msg))
+    if _is_transient_credential_rejection(msg):
+        return TransientAuthError(f"Claude CLI error: {msg}")
     return RuntimeError(f"Claude CLI error: {msg}")
 
 

--- a/src/agento/modules/codex/src/runner.py
+++ b/src/agento/modules/codex/src/runner.py
@@ -6,7 +6,11 @@ import subprocess
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-from agento.framework.agent_manager.errors import AuthenticationError, UsageLimitError
+from agento.framework.agent_manager.errors import (
+    AuthenticationError,
+    TransientAuthError,
+    UsageLimitError,
+)
 from agento.framework.agent_manager.models import AgentProvider
 from agento.framework.agent_manager.runner import TokenRunner
 from agento.framework.runner import RunResult
@@ -21,6 +25,19 @@ _AUTH_PHRASE_RE = re.compile(
     r"\b(401\s+Unauthorized|invalid[_ ]api[_ ]key|"
     r"please\s+(sign|log)\s+in|not\s+authenticated|"
     r"authentication\s+failed|missing\s+bearer)\b",
+    re.IGNORECASE,
+)
+
+# Auth rejections that do NOT prove the credential is dead (revoked/stale access
+# token, typically a concurrent-refresh race). Same structured-event-only discipline
+# as _AUTH_PHRASE_RE, and the same two-signal discipline as the Claude parser:
+# revocation wording must co-occur with credential context, otherwise
+# "workspace access has been revoked" would throttle a perfectly good token.
+# These THROTTLE + fail over (TransientAuthError) rather than poison, and are
+# checked AFTER _AUTH_PHRASE_RE so codex's known-permanent phrases are unaffected.
+_REVOKED_RE = re.compile(r"revok", re.IGNORECASE)
+_CREDENTIAL_WORD_RE = re.compile(
+    r"oauth|access token|credential|bearer|api key|token[_ ]revoked",
     re.IGNORECASE,
 )
 
@@ -109,6 +126,9 @@ class TokenCodexRunner(TokenRunner):
         if (msg := _detect_auth_error(events)) is not None:
             raise AuthenticationError(f"Codex CLI auth error: {msg[:500]}")
 
+        if (msg := _detect_transient_auth_error(events)) is not None:
+            raise TransientAuthError(f"Codex CLI transient auth error: {msg[:500]}")
+
         if (err := _detect_limit_error(events)) is not None:
             msg = str(err.get("message") or err.get("type") or err.get("code") or "usage limit")
             raise UsageLimitError(
@@ -144,6 +164,17 @@ def _detect_auth_error(events: list[dict]) -> str | None:
         err = ev.get("error") or {}
         msg = err.get("message", "") if isinstance(err, dict) else ""
         if msg and _AUTH_PHRASE_RE.search(msg):
+            return msg
+    return None
+
+
+def _detect_transient_auth_error(events: list[dict]) -> str | None:
+    for ev in events:
+        if ev.get("type") != "turn.failed":
+            continue
+        err = ev.get("error") or {}
+        msg = err.get("message", "") if isinstance(err, dict) else ""
+        if msg and _REVOKED_RE.search(msg) and _CREDENTIAL_WORD_RE.search(msg):
             return msg
     return None
 

--- a/tests/integration/test_consumer_token_pool.py
+++ b/tests/integration/test_consumer_token_pool.py
@@ -4,6 +4,7 @@ is exhausted (real MySQL)."""
 from __future__ import annotations
 
 import logging
+import subprocess
 from datetime import UTC, datetime
 from unittest.mock import patch
 
@@ -207,3 +208,137 @@ def test_codex_usage_limit_throttles_and_fails_over(int_db_config, int_consumer_
         int_db_config, int_consumer_config, TokenCodexRunner, "codex", success,
         cheap_model="gpt-5.4-mini",
     )
+
+
+# --- Transient auth (revoked / stale access token) ---------------------------
+# NOTE: unlike the two tests above (which patch ``run`` and raise directly, so they
+# never reach the parser), these patch the SUBPROCESS seam. Everything above it runs
+# for real: _extract_raw -> _parse_output -> parse_claude_output -> _classify_error ->
+# the consumer's except clause -> _handle_transient_auth -> retry_policy -> MySQL.
+
+# The raw stream-json a real `claude -p --output-format stream-json` run emits when the
+# stored OAuth credential is rejected.
+_REVOKED_RAW = (
+    '{"type":"system","subtype":"init","session_id":"sess-revoked","mcp_servers":[]}\n'
+    '{"type":"result","is_error":true,'
+    '"result":"Failed to authenticate. API Error: 401 OAuth access token has been revoked."}\n'
+)
+
+
+def _revoked_process(self, cmd, env):
+    """Stand in for the claude subprocess: rc=1 plus the raw revoked-401 stream-json.
+    Patched at ``_execute_process`` so ``_extract_raw``/``_parse_output`` still run."""
+    return subprocess.CompletedProcess(cmd, 1, _REVOKED_RAW, "")
+
+
+def test_revoked_token_throttles_and_fails_over_instead_of_dead_lettering(
+    int_db_config, int_consumer_config,
+):
+    """Repro of the reported production failure.
+
+    Pool mirrors the reported state: priority-0 token already throttled by a
+    session limit from another job, priority-1 token whose stored access token is
+    revoked, priority-2 token healthy and never tried. Before the fix the revoked
+    401 degraded to a generic RuntimeError, so the token stayed ``status='ok'``,
+    ``retry_with_other_token`` was never set, and the deterministic
+    ``ORDER BY priority ASC`` re-picked the SAME revoked token on every attempt
+    until the job dead-lettered. Expected now: the revoked token is THROTTLED (not
+    poisoned), the job requeues, and attempt 2 lands on the priority-2 token and
+    succeeds.
+    """
+    logger = logging.getLogger("test")
+    _bind_provider("claude")
+    token_limited = _seed_token("prio0-session-limited", priority=0)
+    token_revoked = _seed_token("prio1-revoked", priority=1)
+    token_healthy = _seed_token("prio2-healthy", priority=2)
+
+    # Priority-0 is already in a session-limit cooldown from another job.
+    conn = _test_connection(autocommit=True)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "UPDATE oauth_token SET throttled_until = UTC_TIMESTAMP() + INTERVAL 1 HOUR "
+                "WHERE id = %s",
+                (token_limited,),
+            )
+    finally:
+        conn.close()
+
+    job_id = insert_queued_job(
+        reference_id="AI-REVOKED", idempotency_key="revoked-pool:1", max_attempts=3,
+    )
+
+    # Attempt 1: prio-0 skipped (throttled) -> prio-1 selected -> the real parser
+    # classifies the raw 401 as transient -> throttle + requeue. No token_id on the
+    # exception, so the consumer attributes it to the token IT resolved from the pool.
+    with patch.object(TokenClaudeRunner, "_execute_process", new=_revoked_process):
+        consumer = Consumer(int_db_config, int_consumer_config, logger)
+        job = consumer._try_dequeue()
+        assert job is not None
+        consumer._execute_job(job)
+
+    row = fetch_job(job_id)
+    assert row["status"] == "TODO", "must requeue, not dead-letter"
+    assert row["attempt"] == 1
+    assert row["error_class"] == "TransientAuthError"
+    # THE bug: the revoked token must be throttled, never poisoned.
+    assert _token_status(token_revoked) == "ok"
+    assert _token_throttle(token_revoked) is not None
+    assert _token_throttle(token_revoked) > datetime.now(UTC).replace(tzinfo=None)
+    # The untried healthy token is untouched and still selectable.
+    assert _token_status(token_healthy) == "ok"
+    assert _token_throttle(token_healthy) is None
+
+    update_job(job_id, scheduled_after="2000-01-01 00:00:00")
+
+    # Attempt 2: prio-0 and prio-1 both throttled -> prio-2 selected -> SUCCESS.
+    # Patched at `run` here, not at the subprocess seam: the success path exercises no
+    # classification, so there is nothing for the real parser to prove. Only the failing
+    # attempt above needs to go through `parse_claude_output`.
+    success = RunResult(
+        raw_output="ok", input_tokens=1500, output_tokens=800, cost_usd=0.01,
+        num_turns=1, duration_ms=1000, subtype="success", agent_type="claude",
+    )
+    with patch.object(TokenClaudeRunner, "run", return_value=success):
+        consumer2 = Consumer(int_db_config, int_consumer_config, logger)
+        job2 = consumer2._try_dequeue()
+        assert job2 is not None
+        assert job2.id == job_id
+        consumer2._execute_job(job2)
+
+    row = fetch_job(job_id)
+    assert row["status"] == "SUCCESS", "the healthy prio-2 token must have been used"
+    assert row["attempt"] == 2
+    # No token was permanently poisoned — all three recover on their own.
+    assert _token_status(token_limited) == "ok"
+    assert _token_status(token_revoked) == "ok"
+    assert _token_status(token_healthy) == "ok"
+
+
+def test_revoked_token_dead_letters_only_once_the_pool_is_exhausted(
+    int_db_config, int_consumer_config,
+):
+    """Failover is not infinite: with a single token in the pool a revoked 401 leaves
+    no healthy alternative, so ``retry_with_other_token`` stays False and the job
+    dead-letters immediately (the ``NON_RETRYABLE_ERRORS`` path) rather than burning
+    all three attempts on the same credential."""
+    logger = logging.getLogger("test")
+    _bind_provider("claude")
+    only_token = _seed_token("only-revoked", priority=0)
+    job_id = insert_queued_job(
+        reference_id="AI-REVOKED-SOLO", idempotency_key="revoked-pool:solo", max_attempts=3,
+    )
+
+    with patch.object(TokenClaudeRunner, "_execute_process", new=_revoked_process):
+        consumer = Consumer(int_db_config, int_consumer_config, logger)
+        job = consumer._try_dequeue()
+        assert job is not None
+        consumer._execute_job(job)
+
+    row = fetch_job(job_id)
+    assert row["status"] == "DEAD"
+    assert row["attempt"] == 1
+    assert row["error_class"] == "TransientAuthError"
+    # Still a cooldown, not a poison — an operator does not need `token:reset`.
+    assert _token_status(only_token) == "ok"
+    assert _token_throttle(only_token) is not None

--- a/tests/unit/framework/test_consumer_transient_auth.py
+++ b/tests/unit/framework/test_consumer_transient_auth.py
@@ -1,0 +1,87 @@
+"""Unit: a transient auth failure THROTTLES the offending token (cooldown, not
+poison) and sets ``retry_with_other_token`` when the pool has an alternative."""
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agento.framework.agent_manager.errors import TransientAuthError
+from agento.framework.agent_manager.models import AgentProvider
+from agento.framework.consumer import Consumer
+
+
+def _consumer():
+    return Consumer(MagicMock(), MagicMock(), logging.getLogger("test"))
+
+
+def _job():
+    return SimpleNamespace(id=4242, agent_view_id=2)
+
+
+def _call(healthy: int, exc: TransientAuthError):
+    """Drive _handle_transient_auth with a stubbed DB layer; return the throttle
+    call args recorded by the patched token_store function."""
+    with (
+        patch("agento.framework.consumer.get_connection"),
+        patch("agento.framework.consumer.throttle_token") as throttle,
+        patch("agento.framework.consumer.mark_token_error") as poison,
+        patch(
+            "agento.framework.consumer.count_tokens_for_provider",
+            return_value=(3, healthy),
+        ),
+        patch("agento.framework.consumer.get_event_manager") as em,
+    ):
+        _consumer()._handle_transient_auth(
+            _job(), SimpleNamespace(id=50), AgentProvider.CLAUDE, exc
+        )
+        return throttle, poison, em.return_value.dispatch
+
+
+def test_transient_auth_throttles_and_never_poisons():
+    throttle, poison, _dispatch = _call(
+        healthy=1, exc=TransientAuthError("401 OAuth access token has been revoked")
+    )
+    assert throttle.called
+    # The bug being fixed: id=50 must NOT be flipped to status='error'.
+    assert not poison.called
+
+
+def test_transient_auth_throttle_window_is_in_the_future_and_naive_utc():
+    throttle, _poison, _dispatch = _call(
+        healthy=1, exc=TransientAuthError("401 OAuth access token has been revoked")
+    )
+    until = throttle.call_args.args[2]
+    assert isinstance(until, datetime)
+    assert until.tzinfo is None, "throttled_until must be naive UTC (DB column is UTC)"
+    assert until > datetime.now(UTC).replace(tzinfo=None)
+
+
+def test_transient_auth_sets_failover_flag_when_a_healthy_token_remains():
+    exc = TransientAuthError("401 OAuth access token has been revoked")
+    _call(healthy=2, exc=exc)
+    assert exc.retry_with_other_token is True
+
+
+def test_transient_auth_leaves_failover_flag_false_when_pool_exhausted():
+    exc = TransientAuthError("401 OAuth access token has been revoked")
+    _call(healthy=0, exc=exc)
+    assert exc.retry_with_other_token is False
+
+
+def test_transient_auth_attributes_failure_to_resolved_token_when_token_id_absent():
+    throttle, _poison, _dispatch = _call(
+        healthy=1, exc=TransientAuthError("401 OAuth access token has been revoked")
+    )
+    assert throttle.call_args.args[1] == 50
+
+
+def test_transient_auth_dispatches_token_auth_throttled_after():
+    _throttle, _poison, dispatch = _call(
+        healthy=1, exc=TransientAuthError("401 OAuth access token has been revoked")
+    )
+    names = [c.args[0] for c in dispatch.call_args_list]
+    assert "token_auth_throttled_after" in names
+    # Must NOT masquerade as a poison — workspace_build binds an observer to that one.
+    assert "token_auth_failed_after" not in names

--- a/tests/unit/framework/test_retry_policy.py
+++ b/tests/unit/framework/test_retry_policy.py
@@ -202,3 +202,40 @@ def test_usage_limit_with_alternative_respects_max_attempts():
     decision = evaluate("UsageLimitError", attempt=3, max_attempts=3, error_obj=exc)
     assert decision.should_retry is False
     assert "Max attempts" in decision.reason
+
+
+# --- TransientAuthError ------------------------------------------------------
+# A credential rejection that does NOT prove the token is dead (revoked/stale
+# access token). Handled like a usage limit: cooldown + failover, never a poison.
+
+def test_transient_auth_with_healthy_alternative_retries_onto_next_token():
+    from agento.framework.agent_manager.errors import TransientAuthError
+
+    exc = TransientAuthError("401 OAuth access token has been revoked")
+    exc.retry_with_other_token = True
+    decision = evaluate("TransientAuthError", attempt=1, max_attempts=3, error_obj=exc)
+
+    assert decision.should_retry is True
+    assert decision.delay_seconds == BACKOFF_DELAYS[0]
+    assert "next healthy token" in decision.reason
+
+
+def test_transient_auth_without_healthy_alternative_is_terminal():
+    from agento.framework.agent_manager.errors import TransientAuthError
+
+    exc = TransientAuthError("401 OAuth access token has been revoked")
+    decision = evaluate("TransientAuthError", attempt=1, max_attempts=3, error_obj=exc)
+
+    assert decision.should_retry is False
+    assert "Non-retryable" in decision.reason
+
+
+def test_transient_auth_max_attempts_reached_does_not_retry():
+    from agento.framework.agent_manager.errors import TransientAuthError
+
+    exc = TransientAuthError("401 OAuth access token has been revoked")
+    exc.retry_with_other_token = True
+    decision = evaluate("TransientAuthError", attempt=3, max_attempts=3, error_obj=exc)
+
+    assert decision.should_retry is False
+    assert "Max attempts" in decision.reason

--- a/tests/unit/modules/claude/test_claude_runner.py
+++ b/tests/unit/modules/claude/test_claude_runner.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 
 import pytest
 
-from agento.framework.agent_manager.errors import UsageLimitError
+from agento.framework.agent_manager.errors import TransientAuthError, UsageLimitError
 from agento.framework.runner import McpInitReport, McpServerStatus
 from agento.modules.claude.src.output_parser import (
     AuthenticationError,
@@ -289,3 +289,116 @@ def test_parse_claude_output_mcp_init_survives_missing_result_event():
     assert result.mcp_init == McpInitReport(
         servers=(McpServerStatus("toolbox", "connected"),)
     )
+
+
+# ---- Transient credential rejection (revoked / unrecognised 401) ----
+# The exact message reported from production (seen on two separate jobs).
+_REVOKED_MSG = "Failed to authenticate. API Error: 401 OAuth access token has been revoked."
+
+
+def test_revoked_oauth_token_raises_transient_auth_error_stream_json():
+    raw = json.dumps({"type": "result", "is_error": True, "result": _REVOKED_MSG})
+    with pytest.raises(TransientAuthError, match="has been revoked"):
+        parse_claude_output(raw + "\n")
+
+
+def test_revoked_oauth_token_raises_transient_auth_error_single_json():
+    raw = json.dumps({"is_error": True, "result": _REVOKED_MSG})
+    with pytest.raises(TransientAuthError):
+        parse_claude_output(raw)
+
+
+def test_revoked_is_not_a_permanent_auth_error():
+    # Must NOT poison the token: TransientAuthError is a sibling of
+    # AuthenticationError, never a subclass.
+    raw = json.dumps({"is_error": True, "result": _REVOKED_MSG})
+    with pytest.raises(TransientAuthError) as exc:
+        parse_claude_output(raw)
+    assert not isinstance(exc.value, AuthenticationError)
+
+
+def test_revoked_without_401_code_is_still_transient():
+    raw = json.dumps({"is_error": True, "result": "OAuth access token has been revoked"})
+    with pytest.raises(TransientAuthError):
+        parse_claude_output(raw)
+
+
+@pytest.mark.parametrize("msg", [
+    # Auth verb BEFORE the code (the observed shape) ...
+    "Failed to authenticate. API Error: 401 some brand new wording",
+    # ... and credential words only AFTER it. The matcher must be order-independent.
+    "API Error: 401 OAuth access token rejected",
+    "API Error: 401 invalid bearer token",
+    "API Error: 401 credential rejected",
+    "API Error: 401 Unauthorized",
+])
+def test_unrecognised_401_credential_wording_defaults_to_transient(msg):
+    # Any FUTURE 401 wording must fail over, not degrade to a generic in-place retry.
+    raw = json.dumps({"is_error": True, "result": msg})
+    with pytest.raises(TransientAuthError):
+        parse_claude_output(raw)
+
+
+@pytest.mark.parametrize("msg", [
+    # "401" only as a substring of a token count -> \b401\b must not match.
+    "Prompt is too long: 401234 tokens > 200000 maximum",
+    # A 401 with no credential word at all -> not enough signal to reclassify.
+    "API Error: 401",
+    # A credential word with no rejection signal -> a local file problem, not a bad
+    # pool credential; throttling the token would fix nothing.
+    "the access token could not be read from disk",
+    # Revocation wording with no credential context -> an authorization failure INSIDE
+    # the run (a repo/workspace/permission grant), not a rejected pool credential.
+    # These must not cost the token a 15-minute cooldown.
+    "workspace access has been revoked",
+    "permission has been revoked",
+    "your access to the repository has been revoked",
+])
+def test_matcher_does_not_over_reach(msg):
+    # False positives cost a 15-min throttle + failover, so BOTH signals are required:
+    # a credential-context word AND a rejection signal (\b401\b or revoked).
+    raw = json.dumps({"is_error": True, "result": msg})
+    with pytest.raises(RuntimeError) as exc:
+        parse_claude_output(raw)
+    assert type(exc.value) is RuntimeError
+
+
+def test_revoked_with_credential_context_is_transient_without_a_401():
+    # The rejection signal may be revocation wording rather than a 401 code, as long as
+    # credential context is present.
+    raw = json.dumps({"is_error": True, "result": "the api key credential was revoked"})
+    with pytest.raises(TransientAuthError):
+        parse_claude_output(raw)
+
+
+def test_known_permanent_auth_phrases_still_poison():
+    # Regression guard for the four pre-existing AUTH_ERROR_PHRASES: these are
+    # checked FIRST, so they stay permanent even though they also mention 401/auth.
+    for msg in (
+        "authentication_error: invalid token",
+        "OAuth token has expired",
+        "Not logged in",
+        "Failed to authenticate. API Error: 401 Invalid authentication credentials",
+    ):
+        raw = json.dumps({"is_error": True, "result": msg})
+        with pytest.raises(AuthenticationError):
+            parse_claude_output(raw)
+
+
+def test_limit_phrase_wins_over_generic_401_matcher():
+    # A limit message that happens to carry a 401 must stay a UsageLimitError so its
+    # reset_at (and the 1h throttle default) still apply.
+    raw = json.dumps({
+        "is_error": True,
+        "result": "401 authentication: you've hit your session limit · resets 1pm (Europe/Warsaw)",
+    })
+    with pytest.raises(UsageLimitError) as exc:
+        parse_claude_output(raw)
+    assert exc.value.reset_at is not None
+
+
+def test_plain_runtime_error_is_unchanged():
+    raw = json.dumps({"is_error": True, "result": "something went wrong"})
+    with pytest.raises(RuntimeError) as exc:
+        parse_claude_output(raw)
+    assert type(exc.value) is RuntimeError

--- a/tests/unit/modules/codex/test_codex_runner.py
+++ b/tests/unit/modules/codex/test_codex_runner.py
@@ -1,0 +1,54 @@
+"""Unit: codex NDJSON error classification — permanent auth vs transient credential
+rejection. Both are detected ONLY from a structured ``turn.failed.error``, never from
+raw stdout."""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agento.framework.agent_manager.errors import AuthenticationError, TransientAuthError
+from agento.modules.codex.src.runner import TokenCodexRunner
+
+
+def _turn_failed(message: str) -> str:
+    return json.dumps({"type": "turn.failed", "error": {"message": message}}) + "\n"
+
+
+def _parse(raw: str):
+    return TokenCodexRunner._parse_output(object.__new__(TokenCodexRunner), raw)
+
+
+def test_codex_revoked_token_raises_transient_auth_error():
+    with pytest.raises(TransientAuthError):
+        _parse(_turn_failed("401 the OAuth access token has been revoked"))
+
+
+def test_codex_revoked_is_not_a_permanent_auth_error():
+    with pytest.raises(TransientAuthError) as exc:
+        _parse(_turn_failed("access token has been revoked"))
+    assert not isinstance(exc.value, AuthenticationError)
+
+
+def test_codex_existing_permanent_auth_phrases_are_unchanged():
+    # Scope decision: codex's known auth phrases keep poisoning the token.
+    for msg in ("401 Unauthorized", "invalid_api_key", "please sign in", "not authenticated"):
+        with pytest.raises(AuthenticationError):
+            _parse(_turn_failed(msg))
+
+
+def test_codex_transient_only_matches_structured_turn_failed():
+    # Anti-false-positive discipline: raw stdout mentioning "revoked" must not classify.
+    raw = json.dumps({"type": "item.completed", "text": "the coupon has been revoked"}) + "\n"
+    assert _parse(raw) is not None
+
+
+@pytest.mark.parametrize("msg", [
+    # Revocation wording with no credential context is an authorization failure inside
+    # the run, not a rejected pool credential — same two-signal discipline as Claude.
+    "workspace access has been revoked",
+    "permission has been revoked",
+    "your access to the repository has been revoked",
+])
+def test_codex_revoked_without_credential_context_is_not_transient(msg):
+    assert _parse(_turn_failed(msg)) is not None


### PR DESCRIPTION
## Problem

Jobs dead-lettered on `401 OAuth access token has been revoked` while healthy tokens sat unused in the pool. Observed in production on two separate jobs — three identical attempts, then `DEAD`. A manual re-run succeeded immediately once an unrelated token's throttle expired, so the job itself was fine; this was purely token-handling.

The chain:

1. **`modules/claude/src/output_parser.py`** — `AUTH_ERROR_PHRASES` knew `"OAuth token has expired"` and `"401 Invalid authentication credentials"`, but not `"revoked"`. The message matched nothing → generic `RuntimeError`.
2. **`framework/consumer.py`** — only `AuthenticationError` reaches `_handle_auth_failure` (poison + failover) and only `UsageLimitError` reaches `_handle_usage_limit` (throttle + failover). A generic `RuntimeError` fell into the bare `except Exception: raise` — no poison, no throttle, no `retry_with_other_token`.
3. **`framework/retry_policy.py`** — without that flag the job took the generic retry path, and `select_token`'s deterministic `ORDER BY priority ASC, used_at` handed back the **same** revoked credential on every attempt. Three identical 401s → `DEAD`.

## Why not just poison the token

The offending token was not globally broken — it logged a `SUCCESS` on another job nine minutes later. `mark_token_error` would have pulled a working credential out of the pool until an operator ran `token:reset`. The realistic cause is a stale/raced access-token copy under `AGENTO_CONSUMER_MAX_WORKERS > 1`: a concurrent job rotated the credential while this attempt held an older copy.

So the binary AUTH(poison) / LIMIT(throttle) split had no correct bucket for this.

## Change

A third category, `TransientAuthError` — a **sibling** of `AuthenticationError`, deliberately *not* a subclass (subclassing would let the existing `except AuthenticationError` clause poison it, which is the bug being fixed).

- **Classification** — one rule requiring **two** signals: a credential-context word (`authenticat`, `unauthorized`, `oauth`, `access token`, `credential`, `bearer`, `api key`, `sign in`/`log in`) **and** a rejection signal (`\b401\b` or `revok`). Order-independent, since the observed wording puts the auth verb *before* the code. This also catches future CLI wording instead of letting each new 401 phrasing silently degrade to retry-in-place.
- **Consumer** — `_handle_transient_auth` sets a 15-minute `throttled_until` cooldown (`status` stays `'ok'`; never `mark_token_error`), sets `retry_with_other_token` when the pool has an alternative, and dispatches the new `token_auth_throttled_after` event.
- **Retry policy** — routes down the existing `(next healthy token)` failover branch; terminal when the pool is genuinely exhausted, so attempts aren't burned on one bad credential.

Two guards on matcher breadth, both pinned by tests in *both* directions:

- `\b401\b` with word boundaries, never as a substring — a substring test misfires on `Prompt is too long: 401234 tokens`.
- Bare `token` is excluded from the credential words (Claude says "tokens" about usage accounting constantly). `access token` is in; bare `token` is not.
- Both signals are required — `workspace access has been revoked` and `permission has been revoked` are authorization failures *inside* the run, not rejected pool credentials, and must not cost a token a cooldown.

## Tests

`bin/test` full suite including e2e: **62 passed, 0 failed** (Python 2261 + 8 e2e; JS vitest 27 files / 416 tests).

The integration repro (`tests/integration/test_consumer_token_pool.py`) mocks at the **subprocess seam** (`TokenRunner._execute_process`), not at `run()`, so the real chain executes: `_extract_raw` → `parse_claude_output` → `_classify_error` → the consumer's `except` → `_handle_transient_auth` → `retry_policy` → MySQL. The pool mirrors the reported state — prio-0 throttled by another job's session limit, prio-1 revoked, prio-2 healthy and never tried.

Verified red against `579927e` (production files reverted, test file kept): `assert 'RuntimeError' == 'TransientAuthError'` and `assert 'TODO' == 'DEAD'`. The two pre-existing tests in that file patch `run` and therefore cannot prove classification — that gap is why this one was rewired.

## Scope notes

- **Codex gets revoked wording only.** Its existing `_AUTH_PHRASE_RE` (`401 Unauthorized`, `not authenticated`, …) keeps mapping to permanent `AuthenticationError` — reclassifying a provider with no reported failure is out of scope. The asymmetry is pinned on both sides so it can't drift silently.
- **The generic retry path was not given token-rotation logic.** After classification, an auth-shaped error never reaches it; adding rotation there would change behaviour for unrelated failures (timeouts, tool errors) where re-picking the same token is correct.
- **The `max_workers>1` refresh race is unchanged** and recorded in the CHANGELOG under "Known issues". This makes the symptom survivable (throttle + failover + auto-recover), not gone.
- `token_auth_throttled_after` is intentionally left unbound — in particular it must **not** trigger `workspace_build`'s `ReplaceErroredTokenCredentialsObserver`, which exists to evict a *poisoned* token's dead credentials.

## Operator-visible

A transient-auth throttle needs **no** operator action — the token returns to the pool after 15 minutes. `token:reset` still clears both states. `docs/cli/tokens.md`, `docs/architecture/events.md` and the `data-flow.html` lifecycle callout are updated; the stale `(auto-flagged error on 401)` claim in the token-lifecycle diagram is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
